### PR TITLE
add Position::TrayFixedLeft,TrayFixedRight,TrayFixedCenter

### DIFF
--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -183,7 +183,7 @@ impl<R: Runtime> WindowExt for Window<R> {
                     let x = tray_x + tray_width / 2 - window_size.width / 2;
                     let y = tray_y - window_size.height;
                     if  y < 0 {
-                        PhysicalPosition { x, tray_y }
+                        PhysicalPosition { x, y: tray_y }
                     } else {
                         PhysicalPosition { x, y: tray_y - window_size.height }
                     }

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -179,11 +179,11 @@ impl<R: Runtime> WindowExt for Window<R> {
             }
             #[cfg(feature = "system-tray")]
             TrayFixedCenter => {
-                if let (Some((tray_x, tray_y)), Some((tray_width, _))) = (tray_position, tray_size) {
+                if let (Some((tray_x, tray_y)), Some((tray_width, tray_hight))) = (tray_position, tray_size) {
                     let x = tray_x + tray_width / 2 - window_size.width / 2;
                     let y = tray_y - window_size.height;
                     if  y < 0 {
-                        PhysicalPosition { x, y: tray_y }
+                        PhysicalPosition { x, y: tray_y + tray_hight }
                     } else {
                         PhysicalPosition { x, y: tray_y - window_size.height }
                     }

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -125,18 +125,15 @@ impl<R: Runtime> WindowExt for Window<R> {
             #[cfg(feature = "system-tray")]
             TrayFixedLeft => {
                 if let(Some((tray_x, tray_y)), Some((_, tray_height))) = (tray_position, tray_size) {
-                    let  y = tray_y - window_size.height;
-                    if y < 0 {
-                        PhysicalPosition {
-                            x: tray_x,
-                            y: tray_y + tray_height,
-                        }
-                    } else {
-                        PhysicalPosition {
-                            x: tray_x,
-                            y: tray_y - window_size.height,
-                        }
-                    }
+                    let y = tray_y - window_size.height;
+                    // Choose y value based on the target OS
+                    #[cfg(target_os = "windows")]
+                    let y = if y < 0 { tray_y + tray_height } else { y };
+
+                    #[cfg(target_os = "macos")]
+                    let y = if y < 0 { tray_y } else { y };
+
+                    PhysicalPosition { tray_x, y }
                 } else {
                     panic!("Tray position not set");
                 }
@@ -167,18 +164,15 @@ impl<R: Runtime> WindowExt for Window<R> {
             #[cfg(feature = "system-tray")]
             TrayFixedRight => {
                 if let(Some((tray_x, tray_y)), Some((tray_width, tray_height))) = (tray_position, tray_size) {
-                    let  y = tray_y - window_size.height;
-                    if y < 0 {
-                        PhysicalPosition {
-                            x: tray_x + tray_width,
-                            y: tray_y + tray_height,
-                        }
-                    } else {
-                        PhysicalPosition {
-                            x: tray_x + tray_width,
-                            y: tray_y - window_size.height,
-                        }
-                    }
+                    let y = tray_y - window_size.height;
+                    // Choose y value based on the target OS
+                    #[cfg(target_os = "windows")]
+                    let y = if y < 0 { tray_y + tray_height } else { y };
+
+                    #[cfg(target_os = "macos")]
+                    let y = if y < 0 { tray_y } else { y };
+
+                    PhysicalPosition { tray_x + tray_width, y }
                 } else {
                     panic!("Tray position not set");
                 }
@@ -213,22 +207,25 @@ impl<R: Runtime> WindowExt for Window<R> {
                 {
                     let x = tray_x + tray_width / 2 - window_size.width / 2;
                     let y = tray_y - window_size.height;
-                    if  y < 0 {
-                        PhysicalPosition { x, y: tray_y + tray_height }
-                    } else {
-                        PhysicalPosition { x, y: tray_y - window_size.height }
-                    }
+                    // Choose y value based on the target OS
+                    #[cfg(target_os = "windows")]
+                    let y = if y < 0 { tray_y + tray_height } else { y };
+
+                    #[cfg(target_os = "macos")]
+                    let y = if y < 0 { tray_y } else { y };
+
+                    PhysicalPosition { x, y }
                 } else {
                     panic!("Tray position not set");
                 }
             }
             #[cfg(feature = "system-tray")]
             TrayBottomCenter => {
-                if let (Some((tray_x, tray_y)), Some((tray_width, tray_height))) = (tray_position, tray_size)
+                if let (Some((tray_x, tray_y)), Some((tray_width, _))) = (tray_position, tray_size)
                 {
                     PhysicalPosition {
                         x: tray_x + (tray_width / 2) - (window_size.width / 2),
-                        y: tray_y + tray_height,
+                        y: tray_y,
                     }
                 } else {
                     panic!("Tray position not set");

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -176,7 +176,7 @@ impl<R: Runtime> WindowExt for Window<R> {
                 }
             }
         };
-
+        println!("Tray position: {:?}, Tray size: {:?}", tray_position, tray_size);
         self.set_position(tauri::Position::Physical(physical_pos))
     }
 }

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -33,6 +33,8 @@ pub enum Position {
     TrayCenter,
     #[cfg(feature = "system-tray")]
     TrayBottomCenter,
+    #[cfg(feature = "system-tray")]
+    TrayFixedCenter,
 }
 
 /// A [`Window`] extension that provides extra methods related to positioning.
@@ -170,6 +172,20 @@ impl<R: Runtime> WindowExt for Window<R> {
                     PhysicalPosition {
                         x: tray_x + (tray_width / 2) - (window_size.width / 2),
                         y: tray_y,
+                    }
+                } else {
+                    panic!("Tray position not set");
+                }
+            }
+            #[cfg(feature = "system-tray")]
+            TrayFixedCenter => {
+                if let (Some((tray_x, tray_y)), Some((tray_width, _))) = (tray_position, tray_size) {
+                    let x = tray_x + tray_width / 2 - window_size.width / 2;
+                    let y = tray_y - window_size.height;
+                    if  y < 0 {
+                        PhysicalPosition { x, tray_y }
+                    } else {
+                        PhysicalPosition { x, y: tray_y - window_size.height }
                     }
                 } else {
                     panic!("Tray position not set");

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -133,7 +133,7 @@ impl<R: Runtime> WindowExt for Window<R> {
                     #[cfg(target_os = "macos")]
                     let y = if y < 0 { tray_y } else { y };
 
-                    PhysicalPosition { tray_x, y }
+                    PhysicalPosition { x: tray_x, y }
                 } else {
                     panic!("Tray position not set");
                 }
@@ -172,7 +172,7 @@ impl<R: Runtime> WindowExt for Window<R> {
                     #[cfg(target_os = "macos")]
                     let y = if y < 0 { tray_y } else { y };
 
-                    PhysicalPosition { tray_x + tray_width, y }
+                    PhysicalPosition { x: tray_x + tray_width, y }
                 } else {
                     panic!("Tray position not set");
                 }

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -24,17 +24,21 @@ pub enum Position {
     #[cfg(feature = "system-tray")]
     TrayLeft,
     #[cfg(feature = "system-tray")]
+    TrayFixedLeft,
+    #[cfg(feature = "system-tray")]
     TrayBottomLeft,
     #[cfg(feature = "system-tray")]
     TrayRight,
+    #[cfg(feature = "system-tray")]
+    TrayFixedRight,
     #[cfg(feature = "system-tray")]
     TrayBottomRight,
     #[cfg(feature = "system-tray")]
     TrayCenter,
     #[cfg(feature = "system-tray")]
-    TrayBottomCenter,
-    #[cfg(feature = "system-tray")]
     TrayFixedCenter,
+    #[cfg(feature = "system-tray")]
+    TrayBottomCenter,
 }
 
 /// A [`Window`] extension that provides extra methods related to positioning.
@@ -115,7 +119,26 @@ impl<R: Runtime> WindowExt for Window<R> {
                         y: tray_y - window_size.height,
                     }
                 } else {
-                    panic!("tray position not set");
+                    panic!("Tray position not set");
+                }
+            }
+            #[cfg(feature = "system-tray")]
+            TrayFixedLeft => {
+                if let(Some((tray_x, tray_y)), Some((_, tray_height))) = (tray_position, tray_size) {
+                    let  y = tray_y - window_size.height;
+                    if y < 0 {
+                        PhysicalPosition {
+                            x: tray_x,
+                            y: tray_y + tray_height,
+                        }
+                    } else {
+                        PhysicalPosition {
+                            x: tray_x,
+                            y: tray_y - window_size.height,
+                        }
+                    }
+                } else {
+                    panic!("Tray position not set");
                 }
             }
             #[cfg(feature = "system-tray")]
@@ -136,6 +159,25 @@ impl<R: Runtime> WindowExt for Window<R> {
                     PhysicalPosition {
                         x: tray_x + tray_width,
                         y: tray_y - window_size.height,
+                    }
+                } else {
+                    panic!("Tray position not set");
+                }
+            }
+            #[cfg(feature = "system-tray")]
+            TrayFixedRight => {
+                if let(Some((tray_x, tray_y)), Some((tray_width, tray_height))) = (tray_position, tray_size) {
+                    let  y = tray_y - window_size.height;
+                    if y < 0 {
+                        PhysicalPosition {
+                            x: tray_x + tray_width,
+                            y: tray_y + tray_height,
+                        }
+                    } else {
+                        PhysicalPosition {
+                            x: tray_x + tray_width,
+                            y: tray_y - window_size.height,
+                        }
                     }
                 } else {
                     panic!("Tray position not set");
@@ -166,24 +208,13 @@ impl<R: Runtime> WindowExt for Window<R> {
                 }
             }
             #[cfg(feature = "system-tray")]
-            TrayBottomCenter => {
-                if let (Some((tray_x, tray_y)), Some((tray_width, _))) = (tray_position, tray_size)
-                {
-                    PhysicalPosition {
-                        x: tray_x + (tray_width / 2) - (window_size.width / 2),
-                        y: tray_y,
-                    }
-                } else {
-                    panic!("Tray position not set");
-                }
-            }
-            #[cfg(feature = "system-tray")]
             TrayFixedCenter => {
-                if let (Some((tray_x, tray_y)), Some((tray_width, tray_hight))) = (tray_position, tray_size) {
+                if let (Some((tray_x, tray_y)), Some((tray_width, tray_height))) = (tray_position, tray_size)
+                {
                     let x = tray_x + tray_width / 2 - window_size.width / 2;
                     let y = tray_y - window_size.height;
                     if  y < 0 {
-                        PhysicalPosition { x, y: tray_y + tray_hight }
+                        PhysicalPosition { x, y: tray_y + tray_height }
                     } else {
                         PhysicalPosition { x, y: tray_y - window_size.height }
                     }
@@ -191,8 +222,20 @@ impl<R: Runtime> WindowExt for Window<R> {
                     panic!("Tray position not set");
                 }
             }
+            #[cfg(feature = "system-tray")]
+            TrayBottomCenter => {
+                if let (Some((tray_x, tray_y)), Some((tray_width, tray_height))) = (tray_position, tray_size)
+                {
+                    PhysicalPosition {
+                        x: tray_x + (tray_width / 2) - (window_size.width / 2),
+                        y: tray_y + tray_height,
+                    }
+                } else {
+                    panic!("Tray position not set");
+                }
+            }
         };
-        println!("Tray position: {:?}, Tray size: {:?}", tray_position, tray_size);
+
         self.set_position(tauri::Position::Physical(physical_pos))
     }
 }


### PR DESCRIPTION
In the updated code, three new window positions have been added to the Position enum: TrayFixedLeft, TrayFixedRight, and TrayFixedCenter. These new positions are similar to their respective counterparts TrayLeft, TrayRight, and TrayCenter. However, they take the target operating system into consideration when calculating the y-coordinate of the window position.

For the TrayFixedLeft, TrayFixedRight, and TrayFixedCenter positions, the code checks if the y-coordinate is less than 0. If it is, the y value is set differently based on the target OS:

On Windows: y is set to tray_y + tray_height
On macOS: y is set to tray_y
This ensures that the window is properly positioned relative to the system tray based on the specific behavior of the target operating system.